### PR TITLE
Simplify node install

### DIFF
--- a/recipes/install_node_45.rb
+++ b/recipes/install_node_45.rb
@@ -2,18 +2,7 @@ package "node" do
 	action :remove
 end
 
-# install node repository for latest nodejs rpms
-package "nodesource-release" do
-	notifies :makecache, "yum_repository[nodesource]", :immediately
-end
-
-# ensure yum cache is updated
-yum_repository "nodesource" do
-	action :nothing
-end
-
 package "nodejs" do
+	allow_downgrade true
 	version "4.5.0-1nodesource.el6"
 end
-
-#package "node-gyp"

--- a/recipes/install_node_69.rb
+++ b/recipes/install_node_69.rb
@@ -1,19 +1,8 @@
-%w(node).each do |p|
-	package p do
-		action :remove
-	end
-end
-
-# install node repository for latest nodejs rpms
-package "nodesource-v6" do
-	notifies :makecache, "yum_repository[nodesource]", :immediately
-end
-
-# ensure yum cache is updated
-yum_repository "nodesource" do
-	action :nothing
+package "node" do
+	action :remove
 end
 
 package "nodejs" do
+	allow_downgrade true
 	version "6.9.2-1nodesource.el6"
 end


### PR DESCRIPTION
Simplifies node install by relying on packages copied to our `raven-pub-repo` yum repository.