### PR TITLE
Dev: add tmp_npm tool

### DIFF
--- a/files/default/tmp_npm
+++ b/files/default/tmp_npm
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+BASE_DIR=${TMPDIR:-/var/tmp}
+ORIG_DIR=$PWD
+HASH_CMD="md5sum"
+
+DIR_NAME=`echo $PWD | $HASH_CMD | cut -f1 -d " "`
+
+TMP_DIR=$BASE_DIR/$DIR_NAME
+mkdir -p $TMP_DIR
+
+pushd $TMP_DIR
+
+ln -sf $ORIG_DIR/package.json
+npm $1
+
+# Can't use archive mode cause of the permissions
+rsync --recursive --links --times node_modules $ORIG_DIR
+
+popd

--- a/recipes/install_devtools.rb
+++ b/recipes/install_devtools.rb
@@ -2,3 +2,7 @@ cookbook_file "/usr/bin/build_node_artifact" do
 	mode 0755
 	source "build_node_artifact"
 end
+
+cookbook_file "/usr/bin/tmp_npm" do
+	mode 0755
+end


### PR DESCRIPTION
This adds a utility to run npm install in a temporary directory and then rsync it back to the working directory in order to work around the ever-annoying failure when running npm in vagrant on an nfs share.

References:
https://github.com/npm/npm/issues/3565
https://gist.github.com/kevinastone/8790717