### PR TITLE
Feature/support shrinkwrap

### DIFF
--- a/files/default/tmp_npm
+++ b/files/default/tmp_npm
@@ -12,6 +12,10 @@ mkdir -p $TMP_DIR
 
 pushd $TMP_DIR
 
+if [ "$1" == "shrinkwrap" ]; then
+	rm npm-shrinkwrap.json
+fi
+
 ln -sf $ORIG_DIR/package.json
 npm $1
 

--- a/files/default/tmp_npm
+++ b/files/default/tmp_npm
@@ -18,4 +18,8 @@ npm $1
 # Can't use archive mode cause of the permissions
 rsync --recursive --links --times node_modules $ORIG_DIR
 
+if [ -f npm-shrinkwrap.json]; then
+	cp npm-shrinkwrap.json $ORIG_DIR
+fi
+
 popd


### PR DESCRIPTION
When running npm-shrinkwrap, copy it back to the original directory as well.